### PR TITLE
Add profile page with stats and editing

### DIFF
--- a/firebase-config.js
+++ b/firebase-config.js
@@ -77,12 +77,16 @@ function showAuthScreen() {
     document.getElementById('auth-screen').classList.remove('hidden');
     document.getElementById('main-menu').classList.add('hidden');
     document.getElementById('game-screen').classList.add('hidden');
+    const profile = document.getElementById('profile-screen');
+    if (profile) profile.classList.add('hidden');
 }
 
 function showMainMenu() {
     document.getElementById('auth-screen').classList.add('hidden');
     document.getElementById('main-menu').classList.remove('hidden');
     document.getElementById('game-screen').classList.add('hidden');
+    const profile = document.getElementById('profile-screen');
+    if (profile) profile.classList.add('hidden');
     
     if (currentUser) {
         document.getElementById('current-username').textContent =
@@ -98,6 +102,24 @@ function showGameScreen() {
     document.getElementById('auth-screen').classList.add('hidden');
     document.getElementById('main-menu').classList.add('hidden');
     document.getElementById('game-screen').classList.remove('hidden');
+    const profile = document.getElementById('profile-screen');
+    if (profile) profile.classList.add('hidden');
+}
+
+function showProfileScreen() {
+    document.getElementById('auth-screen').classList.add('hidden');
+    document.getElementById('main-menu').classList.add('hidden');
+    document.getElementById('game-screen').classList.add('hidden');
+    const profile = document.getElementById('profile-screen');
+    if (profile) {
+        profile.classList.remove('hidden');
+    }
+    if (typeof loadProfileStats === 'function') {
+        loadProfileStats();
+    }
+    if (typeof initializeProfilePage === 'function') {
+        initializeProfilePage();
+    }
 }
 
 // Chargement des données utilisateur

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
             <div class="menu-header">
                 <div class="logo">SIO SHOOTER 2D</div>
                 <div class="user-info">
-                    <div class="user-avatar">
+                    <div class="user-avatar" onclick="showProfileScreen()">
                         <i class="fas fa-user"></i>
                     </div>
                     <div class="user-details">
@@ -220,6 +220,43 @@
                               </div>
                           </div>
                       </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Profile Screen -->
+        <div id="profile-screen" class="profile-screen hidden">
+            <div class="profile-container">
+                <button class="close-profile" onclick="showMainMenu()">&times;</button>
+                <div class="profile-avatar">
+                    <i class="fas fa-user"></i>
+                </div>
+                <h2 id="profile-name" style="text-align:center;">Profil</h2>
+
+                <div class="profile-stats">
+                    <h3>Statistiques</h3>
+                    <div class="stats-grid">
+                        <div class="stat-item">Kills: <span id="stat-kills">0</span></div>
+                        <div class="stat-item">Deaths: <span id="stat-deaths">0</span></div>
+                        <div class="stat-item">Parties: <span id="stat-games">0</span></div>
+                    </div>
+                </div>
+
+                <div class="profile-edit">
+                    <h3>Modifier le profil</h3>
+                    <div class="setting-item">
+                        <label>Pseudo</label>
+                        <input type="text" id="profile-page-username">
+                    </div>
+                    <div class="setting-item">
+                        <label>Email</label>
+                        <input type="email" id="profile-page-email">
+                    </div>
+                    <div class="setting-item">
+                        <label>Nouveau mot de passe</label>
+                        <input type="password" id="profile-page-password">
+                    </div>
+                    <button id="profile-page-save-btn" class="save-profile-btn">Enregistrer</button>
                 </div>
             </div>
         </div>

--- a/menu.js
+++ b/menu.js
@@ -26,6 +26,16 @@ document.addEventListener('DOMContentLoaded', () => {
     if (saveProfileBtn) {
         saveProfileBtn.addEventListener('click', saveProfile);
     }
+
+    const pageSaveBtn = document.getElementById('profile-page-save-btn');
+    if (pageSaveBtn) {
+        pageSaveBtn.addEventListener('click', saveProfilePage);
+    }
+
+    const avatar = document.querySelector('.user-avatar');
+    if (avatar) {
+        avatar.addEventListener('click', showProfileScreen);
+    }
 });
 
 // Configuration des écouteurs d'événements
@@ -426,6 +436,81 @@ async function saveProfile() {
     }
 }
 
+function initializeProfilePage() {
+    if (!currentUser) return;
+
+    const usernameInput = document.getElementById('profile-page-username');
+    const emailInput = document.getElementById('profile-page-email');
+    const passwordInput = document.getElementById('profile-page-password');
+    const saveBtn = document.getElementById('profile-page-save-btn');
+
+    if (!usernameInput || !emailInput || !passwordInput || !saveBtn) return;
+
+    usernameInput.value = currentUser.displayName || '';
+    emailInput.value = currentUser.email || '';
+
+    const isGoogle = currentUser.providerData.some(p => p.providerId === 'google.com');
+    [usernameInput, emailInput, passwordInput, saveBtn].forEach(el => {
+        el.disabled = isGoogle;
+    });
+}
+
+async function saveProfilePage() {
+    if (!currentUser) return;
+
+    const username = document.getElementById('profile-page-username').value.trim();
+    const email = document.getElementById('profile-page-email').value.trim();
+    const password = document.getElementById('profile-page-password').value;
+
+    const isGoogle = currentUser.providerData.some(p => p.providerId === 'google.com');
+    if (isGoogle) {
+        showMessage('Modification désactivée pour les comptes Google', 'error');
+        return;
+    }
+
+    try {
+        if (username && username !== currentUser.displayName) {
+            await currentUser.updateProfile({ displayName: username });
+            await saveUserData({ displayName: username });
+        }
+
+        if (email && email !== currentUser.email) {
+            await currentUser.updateEmail(email);
+            await saveUserData({ email: email });
+        }
+
+        if (password) {
+            await currentUser.updatePassword(password);
+            document.getElementById('profile-page-password').value = '';
+        }
+
+        document.getElementById('current-username').textContent =
+            currentUser.displayName || currentUser.email.split('@')[0];
+        document.getElementById('profile-name').textContent =
+            currentUser.displayName || currentUser.email.split('@')[0];
+
+        showMessage('Profil mis à jour', 'success');
+    } catch (error) {
+        console.error('Erreur mise à jour profil:', error);
+        showMessage('Erreur lors de la mise à jour du profil', 'error');
+    }
+}
+
+async function loadProfileStats() {
+    if (!currentUser) return;
+
+    try {
+        const statsRef = database.ref(`users/${currentUser.uid}/stats`);
+        const snapshot = await statsRef.once('value');
+        const stats = snapshot.val() || {};
+        document.getElementById('stat-kills').textContent = stats.kills || 0;
+        document.getElementById('stat-deaths').textContent = stats.deaths || 0;
+        document.getElementById('stat-games').textContent = stats.gamesPlayed || 0;
+    } catch (error) {
+        console.error('Erreur chargement stats:', error);
+    }
+}
+
 // CSS supplémentaire pour les nouvelles fonctionnalités
 const additionalStyles = document.createElement('style');
 additionalStyles.textContent = `
@@ -526,6 +611,7 @@ auth.onAuthStateChanged((user) => {
     if (user) {
         updateOnlineStatus();
         initializeProfileSettings();
+        initializeProfilePage();
     }
 });
 

--- a/style.css
+++ b/style.css
@@ -198,6 +198,7 @@ body {
     align-items: center;
     justify-content: center;
     font-size: 20px;
+    cursor: pointer;
 }
 
 .user-details {
@@ -873,4 +874,71 @@ body {
 
 ::-webkit-scrollbar-thumb:hover {
     background: linear-gradient(45deg, #ff3344, #0099cc);
+}
+
+/* Profile Screen */
+.profile-screen {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: linear-gradient(135deg, #0f1419 0%, #1a252f 100%);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 300;
+}
+
+.profile-container {
+    background: rgba(15, 20, 25, 0.95);
+    padding: 40px;
+    border-radius: 20px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    width: 400px;
+    max-height: 90vh;
+    overflow-y: auto;
+    position: relative;
+}
+
+.close-profile {
+    position: absolute;
+    top: 15px;
+    right: 15px;
+    background: transparent;
+    border: none;
+    color: white;
+    font-size: 24px;
+    cursor: pointer;
+}
+
+.profile-avatar {
+    width: 80px;
+    height: 80px;
+    background: linear-gradient(45deg, #ff4655, #00d4ff);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 32px;
+    margin: 0 auto 15px;
+}
+
+.profile-stats {
+    margin: 20px 0;
+}
+
+.stats-grid {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.stat-item {
+    flex: 1 0 45%;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 8px;
+    padding: 10px;
+    text-align: center;
 }


### PR DESCRIPTION
## Summary
- add profile screen with stats and editable fields
- make avatar clickable to open profile page
- style the new profile screen and make avatar clickable
- hide profile screen when switching screens
- load and save profile data from the new screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68823d1b6518832cb2c90c7d4897a23d